### PR TITLE
Fixes to make sure broker waits for the SUBACK rather than stopping

### DIFF
--- a/mqtt/MQTT.php
+++ b/mqtt/MQTT.php
@@ -959,6 +959,7 @@ class MQTT
                             );
                         }
                     }
+                    unset($this->subscribe_awaits[$msgid]);
                 }
             }
 
@@ -1100,7 +1101,7 @@ class MQTT
 
         while (true) {
             # check if any commands awaits or topics to subscribe
-            if (!$this->cmdstore->countWaits() && empty($this->topics) && empty($this->topics_to_subscribe)) {
+            if (!$this->cmdstore->countWaits() && empty($this->topics) && empty($this->topics_to_subscribe) && empty($this->subscribe_awaits)) {
                 Debug::Log(Debug::INFO, "loop(): No tasks, leaving...");
                 break;
             }


### PR DESCRIPTION
There was a bug where once the loop function was called, the client would not wait to receive the SUBACK. It would then stop the loop as there were no topics to subscribe to and it had not yet officially subscribed to the topics from the original subscribe request. Normally, this is not a problem, but if the session is not clean, one usually receives several other things before getting a SUBACK.